### PR TITLE
Support Emulator Window Resizing

### DIFF
--- a/software/emulator/tinysys.cpp
+++ b/software/emulator/tinysys.cpp
@@ -24,7 +24,6 @@ struct EmulatorContext
 {
 	CEmulator* emulator{ nullptr };
 	SDL_Window* window{ nullptr };
-	SDL_Surface* surface{ nullptr };
 	SDL_Surface* compositesurface{ nullptr };
 	SDL_GameController* gamecontroller{ nullptr };
 };
@@ -356,7 +355,7 @@ uint32_t videoCallback(Uint32 interval, void* param)
 #endif
 
 	// Update window surface
-	SDL_BlitSurface(ctx->compositesurface, nullptr, ctx->surface, nullptr);
+	SDL_BlitScaled(ctx->compositesurface, nullptr, SDL_GetWindowSurface(ctx->window), nullptr);
 	SDL_UpdateWindowSurface(ctx->window);
 
 	return interval;
@@ -621,7 +620,7 @@ int SDL_main(int argc, char** argv)
 		fprintf(stderr, "Error initializing SDL2: %s\n", SDL_GetError());
 		return -1;
 	}
-	ectx.window = SDL_CreateWindow("tinysys", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, WIDTH, HEIGHT+8, SDL_WINDOW_SHOWN);
+	ectx.window = SDL_CreateWindow("tinysys", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, WIDTH, HEIGHT+8, SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE);
 
 	if (TTF_Init() != 0)
 	{
@@ -635,8 +634,7 @@ int SDL_main(int argc, char** argv)
 		return -1;
 	}
 
-	ectx.surface = SDL_GetWindowSurface(ectx.window);
-	if (!ectx.surface)
+	if (!SDL_GetWindowSurface(ectx.window))
 	{
 		fprintf(stderr, "Could not create window surface\n");
 		return -1;
@@ -860,7 +858,6 @@ int SDL_main(int argc, char** argv)
 	SDL_WaitThread(audiothreadID, nullptr);
 	SDL_ClearQueuedAudio(ectx.emulator->m_audioDevice);
 	SDL_FreeSurface(ectx.compositesurface);
-	SDL_FreeSurface(ectx.surface);
 	SDL_DestroyWindow(ectx.window);
 	SDL_CloseAudioDevice(ectx.emulator->m_audioDevice);
 	SDL_Quit();


### PR DESCRIPTION
With this change, you can resize the emulator window and the image stretches. It's not always pretty, but it does always work. 

To handle resizing, we don't even need to respond to the window resize events. We only need to:

1. Tell SDL to make the window resizable
2. Use the correct Surface once it's been resized.
3. When copying from the composite surface to the window surface, we need to use `SDL_BlitScaled` over `SDL_BlitSurface`, which handles resizing.

While debugging it, I realized the `SDL_Surface` is being held onto too long, _and_ the SDL docs explicitly call it out as "do not free" [here](https://wiki.libsdl.org/SDL2/SDL_GetWindowSurface):
> A new surface will be created with the optimal format for the window, if necessary. This surface will be freed when the window is destroyed. Do not free this surface.

So to make management of this simpler, I eliminate the `SDL_Surface*` from the Emulator context entirely. All uses of it use `SDL_GetWindowSurface()` directly. It's a [quick function](https://github.com/libsdl-org/SDL/blob/e28974124a017e343758e830f8d3295dccd2f575/src/video/SDL_video.c#L3523-L3541) once the surface has been created, so caching it isn't a perf win but does make "cache invalidation" style bugs more likely.


A nice follow up change to this would be to resize the window and maintain aspect ratio. I believe this is extra work and leave it as an exercise for a motivated future person:

- Window managers can enforce an aspect ratio, but asking them to changes per WM. That means one function on Windows, one on Mac, one on Linux+X, one of Linux+Wayland, etc
- When blitting the surface to the window, we could use the `SDL_Rect` arguments to preserve aspect ratio and leave the rest of the window black (or some other color)

Attached are some windows at different sizes on a Mac.
<img width="346" alt="image" src="https://github.com/user-attachments/assets/3b0f6007-d671-40bd-b6ac-fe233f10a7ee" />
<img width="1276" alt="image" src="https://github.com/user-attachments/assets/cc3d1b05-b9c1-442a-a24b-a060af55568a" />
<img width="2662" alt="image" src="https://github.com/user-attachments/assets/c7bc5c56-89b5-401d-baf0-4a9de3cced87" />
