### PR TITLE
Fixed leaking SDL surface. FIxed leaking decoded blocks due to looking up map with wrong key.

### DIFF
--- a/software/emulator/rv32.cpp
+++ b/software/emulator/rv32.cpp
@@ -797,7 +797,7 @@ void CRV32::GatherInstructions(CCSRMem* csr, CBus* bus)
 				blk->m_PC = mtvec;
 			else // Vectored
 				blk->m_PC = (mtvec&0xFFFFFFFC) + ((((m_exceptionmode&0x80000000) ? 0x10:0x00) | (m_exceptionmode&0xF))<<2);
-			m_decodedBlocks[blk->m_PC] = blk;
+			m_decodedBlocks[m_exceptionmode] = blk;
 			InjectISRHeader(&blk->m_code);
 			//fprintf(stderr, "new ISR header block (HWI/TMI) %08X\n", mtvec);
 		}
@@ -870,7 +870,7 @@ void CRV32::GatherInstructions(CCSRMem* csr, CBus* bus)
 					blk->m_PC = mtvec;
 				else // Vectored
 					blk->m_PC = (mtvec&0xFFFFFFFC) + ((((m_exceptionmode&0x80000000) ? 0x10:0x00) | (m_exceptionmode&0xF))<<2);
-				m_decodedBlocks[blk->m_PC] = blk;
+				m_decodedBlocks[m_exceptionmode] = blk;
 				InjectISRHeader(&blk->m_code);
 				//fprintf(stderr, "new ISR header block (ECALL/EBREAK/SWI) %08X\n", mtvec);
 			}

--- a/software/emulator/tinysys.cpp
+++ b/software/emulator/tinysys.cpp
@@ -394,6 +394,8 @@ uint32_t statsCallback(Uint32 interval, void* param)
 	snprintf(stats, 512, "%sD$  read hits / misses: %d / %d\n", stats, cpu0->m_dcache.m_readhits, cpu0->m_dcache.m_readmisses);
 	snprintf(stats, 512, "%s   write hits / misses: %d / %d\n", stats, cpu0->m_dcache.m_writehits, cpu0->m_dcache.m_writemisses);
 
+	if (s_statSurface)
+		SDL_FreeSurface(s_statSurface);
 	s_statSurface = TTF_RenderText_Blended_Wrapped(s_debugfont, stats, {255,0,255}, WIDTH);
 
 	cpu0->m_icache.m_hits = 0;


### PR DESCRIPTION
This fixes a couple of memory leaks I noticed in the emulator which eventually lead to the emulator taking down your PC :P